### PR TITLE
Add target.format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ export default {
 	
 - `target` - set files path where generated the sprite or stylesheet.
     - `image` - target image filename;
-    - `css` - can be one of the following, `scss`,`less`,`css`,`stylus`,`json`.see [details](https://github.com/twolfson/spritesheet-templates#templates)
+    - `css` - target css filename;
+    - `format` - optional, can be one of the following, `scss`,`less`,`css`,`stylus`,`json`, see [details](https://github.com/twolfson/spritesheet-templates#templates).
 
 - `cssImageRef` - optional, path by whic h generated image will be referenced in API. If target.image is interpolated, cssImageRef should be interpolated the same way too. Default: `../images/sprite.png`
 

--- a/lib/spritesmith.js
+++ b/lib/spritesmith.js
@@ -36,7 +36,7 @@ module.exports = (customOptions, callback) => {
           //Custom template
           const cssFormat = customTemplate
             ? "spritesmith-custom"
-            : mimeTypes[extname(target.css)];
+            : (target.format || mimeTypes[extname(target.css)]);
           if (typeof customTemplate === "string") {
             templater.addHandlebarsTemplate(
               cssFormat,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
-  "name": "rollup-plugin-sprite",
+  "name": "@zz5840/rollup-plugin-sprite",
   "version": "0.1.2",
   "description": "Create a sprite sheet based on spritesmith for Rollup",
   "main": "index.js",
+  "publishConfig": {
+    "registry":"https://npm.pkg.github.com"
+  },
   "scripts": {
     "test": "ava test/**/*.test.js",
     "coverage": "nyc npm test"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/linjinying/rollup-plugin-sprite.git"
+    "url": "git+https://github.com/zz5840/rollup-plugin-sprite.git"
   },
   "keywords": [
     "rollup",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,35 @@ test("should output sprite image and stylesheet", t => {
   });
 });
 
+test("should output sprite image and texture json", t => {
+  return rollup({
+    input: "./test/samples/src/main.js",
+    plugins: [
+      spritesmith({
+        src: {
+          cwd: "./test/samples/src/images/sprite",
+          glob: "**/*.png"
+        },
+        target: {
+          image: "./test/samples/src/images/sprite.png",
+          css: "./test/samples/src/json/sprite.json",
+          format: 'json_texture'
+        },
+        cssImageRef: "../images/sprite.png",
+        output: {
+          image: "./test/samples/dist/images/sprite.png",
+          css:"./test/samples/dist/json/sprite.json"
+        }
+      })
+    ]
+  }).then(() => {
+    t.true(fs.existsSync("./test/samples/src/images/sprite.png"), "file exists");
+    t.true(fs.existsSync("./test/samples/src/json/sprite.json", "file exist"));
+    t.true(fs.existsSync("./test/samples/dist/images/sprite.png", "file exist"));
+    t.true(fs.existsSync("./test/samples/dist/json/sprite.json", "file exist"));
+  });
+});
+
 test("If set customTemplate option to a template file, should output the custom stylesheet.", t => {
   return rollup({
     input: "./test/samples/src/main.js",


### PR DESCRIPTION
`format` option is useful when outputting different format from extension name of `cssName`.

Output `json_texture` file used by PIXI.js:
```js
spritesmith({
  src: {
    cwd: "./test/samples/src/images/sprite",
    glob: "**/*.png"
  },
  target: {
    image: "./test/samples/src/images/sprite.png",
    css: "./test/samples/src/json/sprite.json",
    format: 'json_texture'
  },
  cssImageRef: "../images/sprite.png",
  output: {
    image: "./test/samples/dist/images/sprite.png",
    css:"./test/samples/dist/json/sprite.json"
  }
})
```